### PR TITLE
レストラン詳細画面に地図表示 #9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,7 @@ gem 'kaminari'
 gem 'config'
 gem 'image_processing', '~> 1.2'
 gem 'rails-i18n'
+
+gem 'dotenv'
+gem 'dotenv-rails'
+gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
+    dotenv (3.1.0)
+    dotenv-rails (3.1.0)
+      dotenv (= 3.1.0)
+      railties (>= 6.1)
     drb (2.2.0)
       ruby2_keywords
     dry-configurable (1.1.0)
@@ -164,6 +168,7 @@ GEM
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
     ffi (1.16.3)
+    geocoder (1.8.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -433,8 +438,11 @@ DEPENDENCIES
   database_cleaner
   debug
   devise
+  dotenv
+  dotenv-rails
   factory_bot_rails
   faker
+  geocoder
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,8 +1,21 @@
 class Restaurant < ApplicationRecord
+  geocoded_by :address # addressは緯度経度を計算するためのフィールド
+  before_validation :geocode, if: ->(obj) { obj.address.present? and obj.address_changed? }
+
   has_many :restaurant_images, dependent: :destroy
   geocoded_by :address
   after_validation :geocode
 
   validates :name, :nearest_station, :budget, :category, :postal_code, :address, :city,
             :district, :phone_number, :business_hours, :description, presence: true
+
+  validate :latitude_and_longitude_present
+
+  private
+
+  def latitude_and_longitude_present
+    return unless (latitude.blank? || longitude.blank?) && address.present?
+
+    errors.add(:base, '緯度と経度は自動的に計算される必要があります。')
+  end
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,6 +1,8 @@
 class Restaurant < ApplicationRecord
   has_many :restaurant_images, dependent: :destroy
+  geocoded_by :address
+  after_validation :geocode
 
   validates :name, :nearest_station, :budget, :category, :postal_code, :address, :city,
-            :district, :latitude, :longitude, :phone_number, :business_hours, :description, presence: true
+            :district, :phone_number, :business_hours, :description, presence: true
 end

--- a/app/views/restaurants/new.html.erb
+++ b/app/views/restaurants/new.html.erb
@@ -40,7 +40,7 @@
 
      <div class="field">
       <%= form.label :address, "住所", class: "block text-sm font-medium text-yellow-700 mt-2" %>
-      <%= form.text_field :address, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500" %>
+      <%= form.text_field :address, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500", autofocus: true,placeholder: "住所を入力してください"  %>
       <%= render partial: 'layouts/shared/field_error', locals: {object: @restaurant, field: :address} %>
     </div>
 
@@ -56,6 +56,9 @@
       <%= render partial: 'layouts/shared/field_error', locals: {object: @restaurant, field: :district} %>
     </div>
 
+<%
+=begin
+%>
      <div class="field">
       <%= form.label :latitude, "緯度", class: "block text-sm font-medium text-yellow-700 mt-2" %>
       <%= form.text_field :latitude, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500" %>
@@ -67,6 +70,9 @@
       <%= form.text_field :longitude, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500" %>
       <%= render partial: 'layouts/shared/field_error', locals: {object: @restaurant, field: :longitude} %>
     </div>
+<%
+=end
+%>
 
      <div class="field">
       <%= form.label :phone_number, "電話番号", class: "block text-sm font-medium text-yellow-700 mt-2" %>

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -9,6 +9,9 @@
       <h2 class="text-2xl font-bold mb-2 text-gray-800"><%= @restaurant.name %></h2>
       <p class="text-md text-gray-600 mb-4">最寄り駅: <%= @restaurant.nearest_station %></p>
       <!-- 中略: その他のレストラン情報 -->
+      <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.budget %></p>
+      <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.category %></p>
+      <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.description %></p>
       <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.description %></p>
     </div>
 

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -1,6 +1,6 @@
 <div class="max-w-4xl mx-auto">
   <%= link_to '編集', edit_restaurant_path(@restaurant), class: "bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
-  <%= link_to '削除', restaurant_path(@restaurant), method: :delete, class: "bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline", data: { confirm: 'レストランを削除します。よろしいですか？' } %>
+  <%= link_to '削除', restaurant_path(@restaurant), data: {turbo_method: :delete, turbo_confirm: 'レストランを削除します。よろしいですか?'} , class: "bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
 </div>
 
 <div class="max-w-4xl mx-auto bg-yellow-50 p-8 shadow-lg rounded-lg">

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -7,12 +7,10 @@
   <div class="flex flex-wrap -mx-2">
     <div class="max-w-4xl w-full md:w-1/2 px-2">
       <h2 class="text-2xl font-bold mb-2 text-gray-800"><%= @restaurant.name %></h2>
-      <p class="text-md text-gray-600 mb-4">最寄り駅: <%= @restaurant.nearest_station %></p>
-      <!-- 中略: その他のレストラン情報 -->
-      <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.budget %></p>
-      <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.category %></p>
-      <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.description %></p>
-      <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.description %></p>
+      <p class="text-md text-gray-600 mb-4"><%= t('restaurants.nearest_station') %>: <%= @restaurant.nearest_station %></p>
+      <p class="text-md text-gray-600 mb-4"><%= t('restaurants.budget') %>: <%= @restaurant.budget %></p>
+      <p class="text-md text-gray-600 mb-4"><%= t('restaurants.category') %>: <%= @restaurant.category %></p>
+      <p class="text-md text-gray-600 mb-4"><%= t('restaurants.description') %>: <%= @restaurant.description %></p>
     </div>
 
     <div class="w-full md:w-1/2 px-2">

--- a/app/views/restaurants/show.html.erb
+++ b/app/views/restaurants/show.html.erb
@@ -1,21 +1,22 @@
 <div class="max-w-4xl mx-auto">
   <%= link_to '編集', edit_restaurant_path(@restaurant), class: "bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" %>
-  <%= link_to '削除', restaurant_path(@restaurant),class: "bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline", data: { turbo_method: :delete, turbo_confirm: 'レストランを削除します。よろしいですか？' } %>
-
+  <%= link_to '削除', restaurant_path(@restaurant), method: :delete, class: "bg-yellow-500 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline", data: { confirm: 'レストランを削除します。よろしいですか？' } %>
 </div>
-<div class="max-w-4xl mx-auto bg-yellow-50 p-8 shadow-lg rounded-lg">
-  <h2 class="text-2xl font-bold mb-2 text-gray-800"><%= @restaurant.name %></h2>
-  <p class="text-md text-gray-600 mb-4">最寄り駅: <%= @restaurant.nearest_station %></p>
-  <p class="text-md text-gray-600 mb-4">予算: ¥<%= @restaurant.budget %></p>
-  <p class="text-md text-gray-600 mb-4">カテゴリ: <%= @restaurant.category %></p>
-  <p class="text-md text-gray-600 mb-4">郵便番号: <%= @restaurant.postal_code %></p>
-  <p class="text-md text-gray-600 mb-4">住所: <%= @restaurant.address %>, <%= @restaurant.city %>, <%= @restaurant.district %></p>
-  <p class="text-md text-gray-600 mb-4">緯度: <%= @restaurant.latitude %>, 経度: <%= @restaurant.longitude %></p>
-  <p class="text-md text-gray-600 mb-4">電話番号: <%= @restaurant.phone_number %></p>
-  <p class="text-md text-gray-600 mb-4">営業時間: <%= @restaurant.business_hours %></p>
-  <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.description %></p>
 
-  <!-- 画像の表示 -->
+<div class="max-w-4xl mx-auto bg-yellow-50 p-8 shadow-lg rounded-lg">
+  <div class="flex flex-wrap -mx-2">
+    <div class="max-w-4xl w-full md:w-1/2 px-2">
+      <h2 class="text-2xl font-bold mb-2 text-gray-800"><%= @restaurant.name %></h2>
+      <p class="text-md text-gray-600 mb-4">最寄り駅: <%= @restaurant.nearest_station %></p>
+      <!-- 中略: その他のレストラン情報 -->
+      <p class="text-md text-gray-600 mb-4">説明: <%= @restaurant.description %></p>
+    </div>
+
+    <div class="w-full md:w-1/2 px-2">
+      <div id="<%= dom_id(@restaurant, 'map') %>" style="height: 300px;"></div>
+    </div>
+  </div>
+
   <% @restaurant.restaurant_images.each_slice(2) do |images| %>
     <div class="flex flex-col md:flex-row md:space-x-4 mt-4">
       <% images.each do |image| %>
@@ -28,3 +29,36 @@
     </div>
   <% end %>
 </div>
+
+<!-- Googleマップ表示エリア(地図を表示) -->
+<div id="<%= dom_id(@restaurant, 'map') %>" style="width: 50%; height: 300px;"></div>
+
+<!-- Googleマップ表示用の Javascript -->
+<script type="text/javascript">
+  function initMap() {
+    initializeMap(<%= @restaurant.latitude %>, <%= @restaurant.longitude %>, '<%= dom_id(@restaurant, 'map') %>', '<%= j @restaurant.address %>');
+  }
+
+  function initializeMap(lat, lng, mapId, address) {
+    const location = {lat: lat, lng: lng};
+    const map = new google.maps.Map(document.getElementById(mapId), {
+      zoom: 15,
+      center: location
+    });
+
+    const marker = new google.maps.Marker({
+      position: location,
+      map: map,
+      title: address
+    });
+
+    const infowindow = new google.maps.InfoWindow({
+      content: '住所：' + address
+    });
+
+    marker.addListener('click', function() {
+      infowindow.open(map, marker);
+    });
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&loading=async&callback=initMap"></script>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google, # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true, # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAP_API_KEY'] # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,29 @@
 ja:
+  devise:
+    sessions:
+      signed_in: "ログインしました。"
+      signed_out: "ログアウトしました。"
+    registrations:
+      signed_up: "アカウント登録が完了しました。"
+      updated: "アカウント情報を更新しました。"
+      destroyed: "アカウントを削除しました。"
+    passwords:
+      send_instructions: "パスワードのリセット手順をメールで送信しました。"
+      updated: "パスワードが正常に変更されました。"
+    confirmations:
+      send_instructions: "アカウント確認の手順をメールで送信しました。"
+      confirmed: "メールアドレスが確認されました。ログインしてください。"
+    unlocks:
+      send_instructions: "アカウントのロック解除手順をメールで送信しました。"
+      unlocked: "アカウントのロックが解除されました。"
+    failures:
+      locked: "アカウントがロックされています。"
+      not_found_in_database: "メールアドレスまたはパスワードが間違っています。"
+      invalid: "メールアドレスまたはパスワードが間違っています。"
+      not_active: "このアカウントは有効ではありません。"
+      timeout: "セッションの有効期限が切れました。もう一度ログインしてください。"
+      inactive: "アカウントが有効化されていません。"
+      unconfirmed: "アカウントの確認が必要です。"
   hello: "こんにちは"
   errors:
     format: "%{message}"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -114,3 +114,9 @@ ja:
         notice: "%{model}が正常に更新されました。"
       destroy:
         notice: "%{model}が正常に削除されました。"
+  restaurants:
+    name: "店名"
+    nearest_station: "最寄り駅"
+    budget: "予算"
+    category: "カテゴリ"
+    description: "説明"

--- a/spec/controllers/restaurants_controller_spec.rb
+++ b/spec/controllers/restaurants_controller_spec.rb
@@ -31,13 +31,22 @@ RSpec.describe RestaurantsController, type: :controller do
             address: '東京都千代田区G地区13-13-13',
             city: '東京都',
             district: '千代田区',
-            latitude: '123',
-            longitude: '123',
             phone_number: '03-1234-4444',
             business_hours: '12:00 - 23:00',
             description: '居心地良い空間の居酒屋です。'
           }
         }
+      end
+
+      before do
+        Geocoder.configure(lookup: :test)
+        Geocoder::Lookup::Test.set_default_stub([{ coordinates: [35.6895, 139.6917] }])
+      end
+
+      it '住所から緯度と経度が自動計算されていること' do
+        post :create, params: restaurant_params
+        expect(Restaurant.last.latitude).to eq(35.6895)
+        expect(Restaurant.last.longitude).to eq(139.6917)
       end
 
       it '登録時、各パラメータに正しく値が設定された場合、SHOW画面が描画されること' do
@@ -74,8 +83,6 @@ RSpec.describe RestaurantsController, type: :controller do
             address: nil,
             city: nil,
             district: nil,
-            latitude: nil,
-            longitude: nil,
             phone_number: nil,
             business_hours: nil,
             description: nil
@@ -105,8 +112,6 @@ RSpec.describe RestaurantsController, type: :controller do
           '住所を入力してください。',
           '市町村を入力してください。',
           '地区を入力してください。',
-          '緯度を入力してください。',
-          '経度を入力してください。',
           '電話番号を入力してください。',
           '営業時間を入力してください。',
           '説明を入力してください。'
@@ -140,8 +145,6 @@ RSpec.describe RestaurantsController, type: :controller do
             address: '東京都千代田区G地区13-13-13',
             city: '東京都',
             district: '千代田区',
-            latitude: '123',
-            longitude: '123',
             phone_number: '03-1234-4444',
             business_hours: '12:00 - 23:00',
             description: '居心地良い空間の居酒屋です。',
@@ -187,8 +190,6 @@ RSpec.describe RestaurantsController, type: :controller do
             address: nil,
             city: nil,
             district: nil,
-            latitude: nil,
-            longitude: nil,
             phone_number: nil,
             business_hours: nil,
             description: nil
@@ -207,8 +208,6 @@ RSpec.describe RestaurantsController, type: :controller do
           '住所を入力してください。',
           '市町村を入力してください。',
           '地区を入力してください。',
-          '緯度を入力してください。',
-          '経度を入力してください。',
           '電話番号を入力してください。',
           '営業時間を入力してください。',
           '説明を入力してください。'

--- a/spec/features/restaurants_edit_spec.rb
+++ b/spec/features/restaurants_edit_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature 'ホーム画面', type: :feature do
         attach_file 'restaurant_for[restaurant_images][photos][]', Rails.root.join('spec/fixtures/files/images/new_image.jpeg') # 画像パスは適宜調整してください
 
         click_button '更新する'
-
+        save_and_open_page
         expect(page).to have_content '更新されたレストラン名'
         expect(page).to have_content '更新された駅名'
         expect(page).to have_content '6000'

--- a/spec/features/restaurants_show_spec.rb
+++ b/spec/features/restaurants_show_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.feature 'ホーム画面', type: :feature do
+  include ActionView::RecordIdentifier
+
+  describe 'レストラン編集画面表示' do
+    let!(:restaurant) { create(:restaurant) } # 事前にレストランを1つ作成
+
+    context 'パラメーターに正しく設定されている場合' do
+      before do
+        visit restaurant_path(restaurant.id)
+      end
+
+      scenario '地図が表示されていることを確認' do
+        map_id = dom_id(restaurant, 'map')
+        expect(page).to have_css("##{map_id}") # `dom_id` ヘルパーメソッドを使用してIDを生成
+      end
+    end
+  end
+end

--- a/spec/features/restaurants_show_spec.rb
+++ b/spec/features/restaurants_show_spec.rb
@@ -3,12 +3,20 @@ require 'rails_helper'
 RSpec.feature 'ホーム画面', type: :feature do
   include ActionView::RecordIdentifier
 
-  describe 'レストラン編集画面表示' do
+  describe 'レストラン詳細画面表示' do
     let!(:restaurant) { create(:restaurant) } # 事前にレストランを1つ作成
 
     context 'パラメーターに正しく設定されている場合' do
       before do
         visit restaurant_path(restaurant.id)
+      end
+
+      scenario '詳細が表示されていること' do
+        expect(page).to have_content restaurant.name
+        expect(page).to have_content restaurant.nearest_station
+        expect(page).to have_content restaurant.budget
+        expect(page).to have_content restaurant.category
+        expect(page).to have_content restaurant.description
       end
 
       scenario '地図が表示されていることを確認' do

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Restaurant, type: :model do
+  context '各パラメータに正しく値が設定された場合' do
+    before do
+      Geocoder.configure(lookup: :test)
+      Geocoder::Lookup::Test.set_default_stub([{ coordinates: [35.6895, 139.6917] }])
+    end
+
+    it '有効であること' do
+      restaurant = Restaurant.new(
+        name: 'テスト店舗',
+        nearest_station: 'テスト駅',
+        budget: 1000,
+        category: 'テストカテゴリー',
+        postal_code: '123-4567',
+        address: 'テスト住所',
+        city: 'テスト市',
+        district: 'テスト区',
+        phone_number: '123-456-7890',
+        business_hours: '10:00 - 22:00',
+        description: 'テスト説明'
+      )
+      expect(restaurant).to be_valid
+    end
+
+    it '住所がある場合、緯度と経度が自動計算されること' do
+      restaurant = Restaurant.new(
+        name: 'テスト店舗',
+        nearest_station: 'テスト駅',
+        budget: 1000,
+        category: 'テストカテゴリー',
+        postal_code: '123-4567',
+        address: 'テスト住所',
+        city: 'テスト市',
+        district: 'テスト区',
+        phone_number: '123-456-7890',
+        business_hours: '10:00 - 22:00',
+        description: 'テスト説明'
+      )
+      restaurant.valid?
+      expect(restaurant.latitude).not_to be_nil
+      expect(restaurant.longitude).not_to be_nil
+    end
+  end
+
+  context '各パラメータに正しく値が設定さなかった場合' do
+    before do
+      Geocoder.configure(lookup: :test)
+      Geocoder::Lookup::Test.add_stub(
+        'フェイルテスト住所', # この住所に対するスタブを設定
+        [{ 'latitude' => nil, 'longitude' => nil }] # ハッシュの配列で緯度と経度を返す
+      )
+    end
+
+    it '住所がない場合、緯度と経度が計算されないこと' do
+      restaurant = Restaurant.new(
+        name: 'テスト店舗',
+        nearest_station: 'テスト駅',
+        budget: 1000,
+        category: 'テストカテゴリー',
+        postal_code: '123-4567',
+        address: '',
+        city: 'テスト市',
+        district: 'テスト区',
+        phone_number: '123-456-7890',
+        business_hours: '10:00 - 22:00',
+        description: 'テスト説明'
+      )
+      restaurant.valid?
+      expect(restaurant.latitude).to be_nil
+      expect(restaurant.longitude).to be_nil
+    end
+
+    it '住所があるが緯度と経度が存在しない場合、エラーが追加されること' do
+      restaurant = Restaurant.new(
+        name: 'テスト店舗',
+        nearest_station: 'テスト駅',
+        budget: 1000,
+        category: 'テストカテゴリー',
+        postal_code: '123-4567',
+        address: 'フェイルテスト住所',
+        city: 'テスト市',
+        district: 'テスト区',
+        phone_number: '123-456-7890',
+        business_hours: '10:00 - 22:00',
+        description: 'テスト説明'
+      )
+
+      restaurant.valid?
+      expect(restaurant.errors[:base]).to include('緯度と経度は自動的に計算される必要があります。')
+    end
+  end
+end


### PR DESCRIPTION
### 概要

レストラン登録時の住所から緯度、経度を算出して保存するし、詳細画面で地図を表示時する。

### 内容

- レストラン登録時の住所から緯度、経度を保存する
- 詳細画面で地図を表示する

### 完了条件

- レストラン登録時の住所から緯度、経度を保存する
- 詳細画面で地図を表示する
- 関連するテストがパスすること